### PR TITLE
ISS-13: Fix the bug when specify Other is selected not working

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-EncounterPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-EncounterPage.xml
@@ -433,26 +433,26 @@
 
                     function disableFn() {
                         group.children("#disabled").fadeTo(250, 0.25);
-                        /* group.children("#disabled").find(":checkbox").attr("checked", false); uncheck */
-                        group.children("#disabled").find("input").attr("disabled", true);
+                        /* group.children("#disabled").find(":checkbox").prop("checked", false); uncheck */
+                        group.children("#disabled").find("input").prop("disabled", true);
                         /* disable */
-                        group.children("#disabled").find("select").attr("disabled", true);
+                        group.children("#disabled").find("select").prop("disabled", true);
                     }
 
                     function enableFn() {
                         group.children("#disabled").fadeTo(250, 1);
-                        group.children("#disabled").find("input").attr("disabled", false);
-                        group.children("#disabled").find("select").attr("disabled", false);
+                        group.children("#disabled").find("input").prop("disabled", false);
+                        group.children("#disabled").find("select").prop("disabled", false);
 
                     }
 
-                    if (jq(this).children("#trigger").find(":checkbox:first").attr("checked") != "checked") {
+                    if (jq(this).children("#trigger").find(":checkbox:first").prop("checked") != "checked") {
                         disableFn();
                     }
 
                     jq(this).children("#trigger").find(":checkbox:first").change(function () {
-                        var checked = jq(this).attr("checked");
-                        if (checked == "checked") {
+                        var checked = jq(this).prop("checked");
+                        if (checked == true) {
                             enableFn();
                         } else {
                             disableFn();


### PR DESCRIPTION
This bug might have come from the update of the JQuery with the lower versions being able to parse **attr** to include **properties** however it seems to be slightly different with newer versions thus better to use **prop**.
Secondly our check was always failing thus no matter whether selected or not, it would default to unchecked thus a better condition-check was to use **true** or **false**

Credit: https://stackoverflow.com/questions/13626517/how-to-remove-disabled-attribute-using-jquery
@ssmusoke 