### PR TITLE
ISS new concerns

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>ugandaemr-iss</artifactId>
-		<version>1.3.5</version>
+		<version>1.3.6</version>
 	</parent>
 
 	<artifactId>ugandaemr-iss-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/ugandaemr/iss/UgandaEMRISSClinicActivator.java
+++ b/api/src/main/java/org/openmrs/module/ugandaemr/iss/UgandaEMRISSClinicActivator.java
@@ -60,6 +60,10 @@ public class UgandaEMRISSClinicActivator extends BaseModuleActivator {
 			
 			// enable the most recent vitals
 			appFrameworkService.enableApp("coreapps.mostRecentVitals");
+			
+			//disable app inorder to add more custom concepts
+			appFrameworkService.disableApp("ugandaemr.dashboardwidget.TPTStatus");
+			
 			log.info("Completed enabling and disabling apps");
 			log.info("Started UgandaEMR ISS Clinic Module");
 			

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>ugandaemr-iss</artifactId>
-		<version>1.3.5</version>
+		<version>1.3.6</version>
 	</parent>
 
 	<artifactId>ugandaemr-iss-omod</artifactId>

--- a/omod/src/main/resources/apps/iss_patient_dashboard_app.json
+++ b/omod/src/main/resources/apps/iss_patient_dashboard_app.json
@@ -8,7 +8,7 @@
       "widget": "latestobsforconceptlist",
       "icon": "icon-user-md",
       "label": "LAST ART VISIT SUMMARY",
-      "concepts": "dcac04cf-30ab-102d-86b0-7a5022ba4115,160288AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,dd2b0b4d-30ab-102d-86b0-7a5022ba4115,b0e53f0a-eaca-49e6-b663-d0df61601b70,7593ede6-6574-4326-a8a6-3d742e843659,dcdff274-30ab-102d-86b0-7a5022ba4115,0b214603-049e-4e57-b871-0e937ac52fd8,bcde6791-6f4e-4af3-a1a6-60cb7feb0df9"
+      "concepts": "b9f2b7c0-2186-4a51-8b62-6380162b32b4,dc8d83e3-30ab-102d-86b0-7a5022ba4115,e17524f4-4445-417e-9098-ecdd134a6b81,dcac04cf-30ab-102d-86b0-7a5022ba4115,160288AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,dd2b0b4d-30ab-102d-86b0-7a5022ba4115,b0e53f0a-eaca-49e6-b663-d0df61601b70,7593ede6-6574-4326-a8a6-3d742e843659,dcdff274-30ab-102d-86b0-7a5022ba4115,0b214603-049e-4e57-b871-0e937ac52fd8,bcde6791-6f4e-4af3-a1a6-60cb7feb0df9"
     },
     "extensions": [
       {
@@ -69,5 +69,57 @@
         }
       }
     ]
+  },
+  {
+  "id": "ugandaemr-iss.dashboardwidget.MCHSummary",
+  "instanceOf": "coreapps.template.dashboardWidget",
+  "description": "Displays obstetric summary of mother receiving MCH services",
+  "order": 10,
+  "config": {
+    "widget": "latestobsforconceptlist",
+    "icon": "icon-user-md",
+    "label": "MCH SUMMARY",
+    "concepts": "ca7ec441-528f-4556-8aae-c4c6db40a330,d858f8cb-fe9e-4131-8d91-cd9929cc53de,5f86d19d-9546-4466-89c0-6f80c101191b,dcc39097-30ab-102d-86b0-7a5022ba4115,1053AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,dca0a383-30ab-102d-86b0-7a5022ba4115,dcc033e5-30ab-102d-86b0-7a5022ba4115,d5b0394c-424f-41db-bc2f-37180dcdbe74,dc548e89-30ab-102d-86b0-7a5022ba4115,1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,160081AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5029d903-51ba-4c44-8745-e97f320739b6"
+  },
+  "requiredPrivilege": "App: ugandaemr-iss.widget.mchSummary",
+  "extensions": [
+    {
+      "id": "org.openmrs.module.coreapps.mostRecentVitals.clinicianDashboardFirstColumn",
+      "appId": "ugandaemr-iss.dashboardwidget.MCHSummary",
+      "extensionPointId": "patientDashboard.firstColumnFragments",
+      "extensionParams": {
+        "provider": "coreapps",
+        "fragment": "dashboardwidgets/dashboardWidget"
+      },
+      "require":"patient.person.gender=='F'"
+    }
+  ]
+},
+  {
+    "id": "ugandaemr-iss.dashboardwidget.TPTStatus",
+    "instanceOf": "coreapps.template.dashboardWidget",
+    "description": "Summary of the patient's TPT status",
+    "order": 5,
+    "config": {
+      "widget": "latestobsforconceptlist",
+      "icon": "icon-user-md",
+      "label": "TPT STATUS ISS",
+      "maxAge": "120m",
+      "concepts": "dce02aa1-30ab-102d-86b0-7a5022ba4115,dce02eca-30ab-102d-86b0-7a5022ba4115,dd2adde2-30ab-102d-86b0-7a5022ba4115,dce02aa1-30ab-102d-86b0-7a5022ba4115,dce02eca-30ab-102d-86b0-7a5022ba4115,dd2adde2-30ab-102d-86b0-7a5022ba4115,37d4ac43-b3b4-4445-b63b-e3acf47c8910,483939c7-79ba-4ca4-8c3e-346488c97fc7,813e21e7-4ccb-4fe9-aaab-3c0e40b6e356,23a6dc6e-ac16-4fa6-8029-155522548d04"
+    },
+    "requiredPrivilege": "App: ugandaemr-iss.widget.tptStatus",
+    "extensions": [
+      {
+        "id": "org.openmrs.module.coreapps.mostRecentVitals.clinicianDashboardFirstColumn",
+        "appId": "ugandaemr-iss.dashboardwidget.TPTStatus",
+        "extensionPointId": "patientDashboard.firstColumnFragments",
+        "extensionParams": {
+          "provider": "coreapps",
+          "fragment": "dashboardwidgets/dashboardWidget"
+        }
+      }
+    ]
   }
+
+
 ]

--- a/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-EncounterPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-EncounterPage.xml
@@ -1254,9 +1254,9 @@
                             <span class="disableARTRegimen">
                                 <excludeIf velocityTest="$patient.age &lt;15">
                                     <span class="RegimenEnableDisable1">
-                                        <obs id="90315" conceptId="90315" labelText="Regimen:"
-                                         answerConceptIds="99005,99006,99039,99040,99044,99046,99284,99286,99885,99888,163017,99887,164977,164978,90002"
-                                         answerLabels="1c-AZT-3TC-NVP,1d-AZT-3TC-EFV,1e-TDF-3TC-NVP,1f-TDF-3TC-EFV,2b-TDF-3TC-LPV/r,2e-AZT-3TC-LPV/r,2c-AZT-ABC-LPV/r,2j-AZT-3TC-ATV/r,1i-ABC-3TC-EFV,2h-ABC-3TC-ATV/r,2g-ABC-3TC-LPV/r,2f-TDF-3TC-ATV/r,TDF/3TC/DTG,ABC/3TC/DTG,Other"/>
+                                        <obs id="90315" conceptId="90315" labelText="Regimen:" class="long-value-select" />
+                                       <!--  answerConceptIds="99005,     99006         ,99039         ,99040          ,99044          ,99046           ,99284           ,99286           ,99885         ,99888           ,163017          ,99887           ,164977      ,164978    ,90002"
+                                         answerLabels="1c-AZT-3TC-NVP,1d-AZT-3TC-EFV,1e-TDF-3TC-NVP,1f-TDF-3TC-EFV,2b-TDF-3TC-LPV/r,2e-AZT-3TC-LPV/r,2c-AZT-ABC-LPV/r,2j-AZT-3TC-ATV/r,1i-ABC-3TC-EFV,2h-ABC-3TC-ATV/r,2g-ABC-3TC-LPV/r,2f-TDF-3TC-ATV/r,TDF/3TC/DTG,ABC/3TC/DTG,Other"/> -->
                                     </span>
                                     <span class="RegimenEnableDisableChild1">
                                         <obs id="br" conceptId="99126" size="18" labelText="Specify"/>
@@ -1265,9 +1265,9 @@
                                 </excludeIf>
                                 <excludeIf velocityTest="$patient.age &gt;14">
                                     <span class="RegimenEnableDisable1">
-                                        <obs id="90315" conceptId="90315" labelText="Regimen:"
-                                         answerConceptIds="99005,99006,99039,99040,99044,99046,99284,99286,99885,99888,163017,90002,164977,99887,164978"
-                                         answerLabels="4c-AZT-3TC-NVP,4d-AZT-3TC-EFV,4j-TDF-3TC-NVP,4i-TDF-3TC-EFV,5b-TDF-3TC-LPV/r,4h-AZT-3TC-LPV/r,5l-AZT-3TC-ATV/r,5j-ABC-3TC-NVP,5i-ABC-3TC-EFV,5m-ABC-3TC-ATV/r,5k-ABC-3TC-LPV/r,TDF/3TC/DTG,ABC/3TC/DTG,2f-TDF-3TC-ATV/r,Other"/>
+                                        <obs id="90315" conceptId="90315" labelText="Regimen:" class="long-value-select"/>
+                                       <!--  answerConceptIds="99005,99006,99039,99040,99044,99046,99284,99286,99885,99888,163017,90002,164977,99887,164978"
+                                         answerLabels="4c-AZT-3TC-NVP,4d-AZT-3TC-EFV,4j-TDF-3TC-NVP,4i-TDF-3TC-EFV,5b-TDF-3TC-LPV/r,4h-AZT-3TC-LPV/r,5l-AZT-3TC-ATV/r,5j-ABC-3TC-NVP,5i-ABC-3TC-EFV,5m-ABC-3TC-ATV/r,5k-ABC-3TC-LPV/r,TDF/3TC/DTG,ABC/3TC/DTG,2f-TDF-3TC-ATV/r,Other"/> -->
                                     </span>
                                     <span class="RegimenEnableDisableChild1">
                                         <obs id="br" conceptId="99126" size="18" labelText="Specify"/>

--- a/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-SummaryPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/122a-HIVCare_ARTCard-SummaryPage.xml
@@ -1338,12 +1338,10 @@
                     <tbody>
                     <tr>
                         <obsgroup groupingConceptId="99162">
-                            <td class="ARTStartEnableDisable1">
                                 <div class="right-inner-addon ">
                                     <i class=" icon-calendar small start-art-icon"></i>
-                                    <obs id="99161" conceptId="99161" labelText="At Start ART:"/>
+                                    <obs id="99161" conceptId="99161" labelText="At Start ART:" allowFutureDates="true"/>
                                 </div>
-                            </td>
                             <td class="ARTStartEnableDisableChild1">
                                 <span class="ArtCareEnableDisable2">
                                 <obs conceptId="99061"

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>ugandaemr-iss</artifactId>
-	<version>1.3.5</version>
+	<version>1.3.6</version>
 	<packaging>pom</packaging>
 	<name>UgandaEMR ISS Clinic</name>
 	<description>UgandaEMR customizations for ISS Youth Clinic Mulago</description>


### PR DESCRIPTION
1. Bumped version from 1.3.5 to 1.3.6 
2. Cervical cancer, status is not reflected on the dash board.
3. The status for TPT is only shown for patients who completed not for those currently on treatment.
4. Comments made for review don’t appear instead old ones are reflected.
5. Some patient’s regimen “pills given” doesn’t accept to be added into the system.
6. The date when the client tests positive is different from ART start date so it doesn’t get saved because OPEN MRS requests it to be equal.
7. Current viral load results on the dash board are not displayed.
8. The system is unable to update/capture actual pead regimens on the encounter form
and patient dashboard e.g. The current ARV regimen displayed on the dashboard is
TDF-3TC-DTG, the encounter form has ABC-3TC-DTG (Actual regimen) regimen
captured; however, when generating reports/ exports, it shows TDF-3TC-DTG for all
peads in the care which is untrue.
